### PR TITLE
gh-actions: use Trusted Publishing, fix warnings, add pypy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -24,17 +27,13 @@ jobs:
           - "3.8"
           - "3.12"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - name: Set up pip cache
-        if: runner.os == 'Linux'
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pip-
+          cache: 'pip'
+      - if: ${{ (matrix.py == '3.8') && (matrix.os == 'macos-latest') }}
+        run: python -m pip install --upgrade pip
       - name: Install Hatch
         run: pipx install hatch
       - name: Check types
@@ -66,17 +65,13 @@ jobs:
           - py: "3.14-dev"
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - name: Set up pip cache
-        if: runner.os == 'Linux'
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
-          restore-keys: ${{ runner.os }}-pip-
+          cache: 'pip'
+      - if: ${{ matrix.os == 'macos-latest' }}
+        run: python -m pip install --upgrade pip
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests
@@ -87,14 +82,14 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: [test, check]
     permissions:
+      attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install hatch
       - name: Build dist
         run: hatch build
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           attestations: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
           cache: 'pip'
-      - if: ${{ (matrix.py == '3.8') && (matrix.os == 'macos-latest') }}
-        run: python -m pip install --upgrade pip
       - name: Install Hatch
         run: pipx install hatch
       - name: Check types
@@ -64,14 +62,14 @@ jobs:
             os: ubuntu-latest
           - py: "3.14-dev"
             os: ubuntu-latest
+          - py: "pypy3.10"
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
           cache: 'pip'
-      - if: ${{ matrix.os == 'macos-latest' }}
-        run: python -m pip install --upgrade pip
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests


### PR DESCRIPTION
For pypi-publish, remove password and rely on Trusted Publishing configured in PyPI, and also add `attestations:write` permission to go with `attestations:true`.

Also clean up caching to `with.cache:pip` and update action versions and installed pip to fix warnings.